### PR TITLE
Add missing typing and pyright checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
         run: isort . --check --diff
 
       - name: Ensure pyright is happy
-        uses: pyright d20 tests
+        uses: pyright d20

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,13 @@ jobs:
           python-version: "3.10"
 
       - name: Install deps
-        run: pip install black isort
+        run: pip install black isort pyright
 
       - name: Ensure code is blackified
         run: black . --check --diff
 
       - name: Ensure imports are sorted
         run: isort . --check --diff
+
+      - name: Ensure pyright is happy
+        uses: pyright d20 tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,15 +1,14 @@
 name: Test Package
 
-on: [ push ]
+on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.x" ]
-        numpy-version: [ false, <2.0.0 ]
+        python-version: ["3.10", "3.11", "3.12", "3.x"]
+        numpy-version: [false, <2.0.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -18,8 +17,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'tests/requirements.txt'
+          cache: "pip"
+          cache-dependency-path: "tests/requirements.txt"
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ testenv/
 tree.png
 .DS_Store
 
+.vscode

--- a/d20/__init__.py
+++ b/d20/__init__.py
@@ -1,4 +1,4 @@
-from . import diceast as ast, rand, utils
+from . import diceast as ast, rand, utils # type: ignore
 from .dice import *
 from .errors import *
 from .expression import *

--- a/d20/context.py
+++ b/d20/context.py
@@ -1,0 +1,31 @@
+from .errors import TooManyRolls
+
+__all__ = ("RollContext",)
+
+
+class RollContext:
+    """
+    A class to track information about rolls to ensure all rolls halt eventually.
+
+    To use this class, pass an instance to the constructor of :class:`d20.Roller`.
+    """
+
+    def __init__(self, max_rolls: int = 1000):
+        self.max_rolls = max_rolls
+        self.rolls = 0
+        self.reset()
+
+    def reset(self):
+        """Called at the start of each new roll."""
+        self.rolls = 0
+
+    def count_roll(self, n: int = 1):
+        """
+        Called each time a die is about to be rolled.
+
+        :param int n: The number of rolls about to be made.
+        :raises d20.TooManyRolls: if the roller should stop rolling dice because too many have been rolled.
+        """
+        self.rolls += n
+        if self.rolls > self.max_rolls:
+            raise TooManyRolls("Too many dice rolled.")

--- a/d20/dice.py
+++ b/d20/dice.py
@@ -1,6 +1,7 @@
 import random
 from enum import IntEnum
-from typing import Callable, Mapping, MutableMapping, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Type, Union
+import typing
 
 import cachetools
 import lark
@@ -16,10 +17,6 @@ __all__ = ("CritType", "AdvType", "RollResult", "Roller")
 POSSIBLE_COMMENT_AMBIGUITIES = {
     "*",
 }
-
-TreeType = TypeVar("TreeType", bound=ast.ChildMixin)
-ASTNode = TypeVar("ASTNode", bound=ast.Node)
-ExpressionNode = TypeVar("ExpressionNode", bound=Number)
 
 
 class CritType(IntEnum):
@@ -47,7 +44,7 @@ class RollResult:
     Holds information about the result of a roll. This should generally not be constructed manually.
     """
 
-    def __init__(self, the_ast: ASTNode, the_roll: Expression, stringifier: Stringifier):
+    def __init__(self, the_ast: ast.Node, the_roll: Expression, stringifier: Stringifier):
         """
         :type the_ast: ast.Node
         :type the_roll: d20.Expression
@@ -111,11 +108,11 @@ class RollResult:
 class Roller:
     """The main class responsible for parsing dice into an AST and evaluating that AST."""
 
-    def __init__(self, context: RollContext = None, rng: random.Random = rand.random_impl):
+    def __init__(self, context: Optional[RollContext] = None, rng: random.Random = rand.random_impl):
         if context is None:
             context = RollContext()
 
-        self._nodes: Mapping[Type[ASTNode], Callable[[ASTNode], ExpressionNode]] = {
+        self._nodes: Mapping[Type[ast.Node], Callable[[Any], Number]] = {
             ast.Expression: self._eval_expression,
             ast.AnnotatedNumber: self._eval_annotatednumber,
             ast.Literal: self._eval_literal,
@@ -127,13 +124,13 @@ class Roller:
             ast.OperatedDice: self._eval_operateddice,
             ast.Dice: self._eval_dice,
         }
-        self._parse_cache: MutableMapping[str, ASTNode] = cachetools.LFUCache(256)
+        self._parse_cache: MutableMapping[str, ast.Node] = cachetools.LFUCache(256)
         self.context = context
         self.rng = rng
 
     def roll(
         self,
-        expr: Union[str, ASTNode],
+        expr: Union[str, ast.Node],
         stringifier: Optional[Stringifier] = None,
         allow_comments: bool = False,
         advantage: AdvType = AdvType.NONE,
@@ -163,6 +160,7 @@ class Roller:
             dice_tree = utils.ast_adv_copy(dice_tree, advantage)
 
         dice_expr = self._eval(dice_tree)
+        dice_expr = typing.cast(Expression, dice_expr)
         return RollResult(dice_tree, dice_expr, stringifier)
 
     # parsers
@@ -189,14 +187,20 @@ class Roller:
         # see if this expr is in cache
         clean_expr = expr.replace(" ", "")
         if clean_expr in self._parse_cache:
-            return self._parse_cache[clean_expr]
-        dice_tree = ast.parser.parse(expr, start="expr")
-        self._parse_cache[clean_expr] = dice_tree
+            dice_tree = self._parse_cache[clean_expr]
+            dice_tree = typing.cast(ast.Expression, dice_tree)
+        else:
+            dice_tree = ast.parser.parse(expr, start="expr")  # type: ignore
+            dice_tree = typing.cast(ast.Node, dice_tree)
+            self._parse_cache[clean_expr] = dice_tree
+            dice_tree = typing.cast(ast.Expression, dice_tree)
         return dice_tree
 
     def _parse_with_comments(self, expr: str) -> ast.Expression:
         try:
-            return ast.parser.parse(expr, start="commented_expr")
+            dice_tree = ast.parser.parse(expr, start="commented_expr")  # type: ignore
+            dice_tree = typing.cast(ast.Expression, dice_tree)
+            return dice_tree
         except lark.UnexpectedInput as ui:
             # if the statement up to the unexpected token ends with an operator, remove that from the end
             successful_fragment = expr[: ui.pos_in_stream]
@@ -208,39 +212,41 @@ class Roller:
             else:
                 raise
             # and parse again (handles edge cases like "1d20 keep the dragon grappled")
-            result = ast.parser.parse(successful_fragment, start="commented_expr")
-            result.comment = force_comment
-            return result
+            dice_tree = ast.parser.parse(successful_fragment, start="commented_expr")  # type: ignore
+            dice_tree = typing.cast(ast.Expression, dice_tree)
+            dice_tree.comment = force_comment
+            return dice_tree
 
     # evaluator
-    def _eval(self, node: ASTNode) -> ExpressionNode:
+    def _eval(self, node: ast.Node) -> Number:
         # noinspection PyUnresolvedReferences
         # for some reason pycharm thinks this isn't a valid dict operation
         handler = self._nodes[type(node)]
         return handler(node)
 
     def _eval_expression(self, node: ast.Expression) -> Expression:
-        return Expression(self._eval(node.roll), node.comment)
+        return Expression(self._eval(node.roll), node.comment, kept=True, annotation=None)
 
-    def _eval_annotatednumber(self, node: ast.AnnotatedNumber) -> ExpressionNode:
+    def _eval_annotatednumber(self, node: ast.AnnotatedNumber) -> Number:
         target = self._eval(node.value)
         target.annotation = "".join(node.annotations)
         return target
 
     def _eval_literal(self, node: ast.Literal) -> Literal:
-        return Literal(node.value)
+        return Literal(node.value, kept=True, annotation=None)
 
     def _eval_parenthetical(self, node: ast.Parenthetical) -> Parenthetical:
-        return Parenthetical(self._eval(node.value))
+        return Parenthetical(self._eval(node.value), kept=True, annotation=None)
 
     def _eval_unop(self, node: ast.UnOp) -> UnOp:
-        return UnOp(node.op, self._eval(node.value))
+        return UnOp(node.op, self._eval(node.value), kept=True, annotation=None)
 
     def _eval_binop(self, node: ast.BinOp) -> BinOp:
-        return BinOp(self._eval(node.left), node.op, self._eval(node.right))
+        return BinOp(self._eval(node.left), node.op, self._eval(node.right), kept=True, annotation=None)
 
-    def _eval_operatedset(self, node: ast.OperatedSet) -> ExpressionNode:
+    def _eval_operatedset(self, node: ast.OperatedSet) -> Number:
         target = self._eval(node.value)
+        target = typing.cast(Set, target)
         for op in node.operations:
             the_op = SetOperator.from_ast(op)
             the_op.operate(target)
@@ -248,10 +254,10 @@ class Roller:
         return target
 
     def _eval_numberset(self, node: ast.NumberSet) -> Set:
-        return Set([self._eval(n) for n in node.values])
+        return Set([self._eval(n) for n in node.values], kept=True, annotation=None)
 
-    def _eval_operateddice(self, node: ast.OperatedDice) -> ExpressionNode:
+    def _eval_operateddice(self, node: ast.OperatedDice) -> Number:
         return self._eval_operatedset(node)
 
     def _eval_dice(self, node: ast.Dice) -> Dice:
-        return Dice.new(node.num, node.size, context=self.context, rng=self.rng)
+        return Dice.new(node.num, node.size, context=self.context, rng=self.rng, kept=True, annotation=None)

--- a/d20/dice.py
+++ b/d20/dice.py
@@ -6,11 +6,12 @@ import cachetools
 import lark
 
 from . import diceast as ast, rand, utils
+from .context import *
 from .errors import *
 from .expression import *
 from .stringifiers import MarkdownStringifier, Stringifier
 
-__all__ = ("CritType", "AdvType", "RollContext", "RollResult", "Roller")
+__all__ = ("CritType", "AdvType", "RollResult", "Roller")
 
 POSSIBLE_COMMENT_AMBIGUITIES = {
     "*",
@@ -39,34 +40,6 @@ class AdvType(IntEnum):
     NONE = 0
     ADV = 1
     DIS = -1
-
-
-class RollContext:
-    """
-    A class to track information about rolls to ensure all rolls halt eventually.
-
-    To use this class, pass an instance to the constructor of :class:`d20.Roller`.
-    """
-
-    def __init__(self, max_rolls=1000):
-        self.max_rolls = max_rolls
-        self.rolls = 0
-        self.reset()
-
-    def reset(self):
-        """Called at the start of each new roll."""
-        self.rolls = 0
-
-    def count_roll(self, n=1):
-        """
-        Called each time a die is about to be rolled.
-
-        :param int n: The number of rolls about to be made.
-        :raises d20.TooManyRolls: if the roller should stop rolling dice because too many have been rolled.
-        """
-        self.rolls += n
-        if self.rolls > self.max_rolls:
-            raise TooManyRolls("Too many dice rolled.")
 
 
 class RollResult:

--- a/d20/diceast.py
+++ b/d20/diceast.py
@@ -1,5 +1,6 @@
 import abc
 import os
+from typing import Any, Generic, Optional, TypeVar
 
 from lark import Lark, Token, Transformer
 
@@ -7,59 +8,58 @@ from lark import Lark, Token, Transformer
 
 
 # noinspection PyMethodMayBeStatic
-# shush, you
-class RollTransformer(Transformer):
+class RollTransformer(Transformer[Any, Any]):
     _comma = object()
 
-    def expr(self, num):
+    def expr(self, num: Any):
         return Expression(*num)
 
-    def commented_expr(self, numcomment):
+    def commented_expr(self, numcomment: Any):
         return Expression(*numcomment)
 
-    def comparison(self, binop):
+    def comparison(self, binop: Any):
         return BinOp(*binop)
 
-    def a_num(self, binop):
+    def a_num(self, binop: Any):
         return BinOp(*binop)
 
-    def m_num(self, binop):
+    def m_num(self, binop: Any):
         return BinOp(*binop)
 
-    def u_num(self, unop):
+    def u_num(self, unop: Any):
         return UnOp(*unop)
 
-    def numexpr(self, num_anno):
+    def numexpr(self, num_anno: Any):
         return AnnotatedNumber(*num_anno)
 
-    def literal(self, num):
+    def literal(self, num: Any):
         return Literal(*num)
 
-    def set(self, opset):
+    def set(self, opset: Any):
         return OperatedSet(*opset)
 
-    def set_op(self, opsel):
+    def set_op(self, opsel: Any):
         return SetOperator.new(*opsel)
 
-    def setexpr(self, the_set):
+    def setexpr(self, the_set: Any):
         if len(the_set) == 1 and the_set[-1] is not self._comma:
             return Parenthetical(the_set[0])
         elif len(the_set) and the_set[-1] is self._comma:
             the_set = the_set[:-1]
         return NumberSet(the_set)
 
-    def dice(self, opdice):
+    def dice(self, opdice: Any):
         return OperatedDice(*opdice)
 
-    def dice_op(self, opsel):
+    def dice_op(self, opsel: Any):
         return SetOperator.new(*opsel)
 
-    def diceexpr(self, dice):
+    def diceexpr(self, dice: Any):
         if len(dice) == 1:
             return Dice(1, *dice)
         return Dice(*dice)
 
-    def selector(self, sel):
+    def selector(self, sel: Any):
         return SetSelector(*sel)
 
     def comma(self, _):
@@ -67,11 +67,15 @@ class RollTransformer(Transformer):
 
 
 # ===== helper mixin =====
-class ChildMixin:
+ChildType = TypeVar("ChildType", bound="ChildMixin")
+
+
+class ChildMixin(Generic[ChildType]):
     """A mixin that tree nodes must implement to support tree traversal utilities."""
 
     @property
-    def children(self):
+    @abc.abstractmethod
+    def children(self) -> list[ChildType]:
         """
         Returns a list of this node's roll children.
 
@@ -80,7 +84,7 @@ class ChildMixin:
         raise NotImplementedError
 
     @property
-    def left(self):
+    def left(self) -> ChildType | None:
         """
         Returns the node's leftmost child, or None if there are no children.
 
@@ -89,11 +93,11 @@ class ChildMixin:
         return self.children[0] if self.children else None
 
     @left.setter
-    def left(self, value):
+    def left(self, value: ChildType) -> None:
         self.set_child(0, value)
 
     @property
-    def right(self):
+    def right(self) -> ChildType | None:
         """
         Returns the node's rightmost child, or None if there are no children.
 
@@ -102,14 +106,15 @@ class ChildMixin:
         return self.children[-1] if self.children else None
 
     @right.setter
-    def right(self, value):
+    def right(self, value: ChildType) -> None:
         self.set_child(-1, value)
 
-    def _child_set_check(self, index):
+    def _child_set_check(self, index: int):
         if index > (len(self.children) - 1) or index < -len(self.children):
             raise IndexError
 
-    def set_child(self, index, value):
+    @abc.abstractmethod
+    def set_child(self, index: int, value: ChildType) -> None:
         """
         Sets the ith child of this object.
 
@@ -122,30 +127,15 @@ class ChildMixin:
 
 
 # ===== ast classes =====
-class Node(abc.ABC, ChildMixin):
+class Node(abc.ABC, ChildMixin["Node"]):
     """
     The base class for all AST nodes.
 
     A Node has no specific attributes, but supports all the methods in :class:`~d20.ast.ChildMixin` for traversal.
     """
 
-    # overridden here for type checking
-    def set_child(self, index, value):
-        """
-        Sets the ith child of this Node.
-
-        :param int index: Which child to set.
-        :param value: The Node to set it to.
-        :type value: Node
-        """
-        super().set_child(index, value)
-
-    @property
-    def children(self):
-        """:rtype: list of Node"""
-        raise NotImplementedError
-
-    def __str__(self):
+    @abc.abstractmethod
+    def __str__(self) -> str:
         raise NotImplementedError
 
 
@@ -154,7 +144,10 @@ class Expression(Node):  # expr
 
     __slots__ = ("roll", "comment")
 
-    def __init__(self, roll, comment=None):
+    roll: Node
+    comment: Optional[str]
+
+    def __init__(self, roll: Node, comment: Optional[str] = None):
         self.roll = roll
         self.comment = str(comment) if comment is not None else None
 
@@ -162,7 +155,7 @@ class Expression(Node):  # expr
     def children(self):
         return [self.roll]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.roll = value
 
@@ -177,7 +170,10 @@ class AnnotatedNumber(Node):  # numexpr
 
     __slots__ = ("value", "annotations")
 
-    def __init__(self, value, *annotations):
+    value: Node
+    annotations: list[str]
+
+    def __init__(self, value: Node, *annotations: Token | str):
         """
         :type value: Node
         :type annotations: lark.Token or str
@@ -190,7 +186,7 @@ class AnnotatedNumber(Node):  # numexpr
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.value = value
 
@@ -201,7 +197,9 @@ class AnnotatedNumber(Node):  # numexpr
 class Literal(Node):  # literal
     __slots__ = ("value",)
 
-    def __init__(self, value):
+    value: int | float
+
+    def __init__(self, value: Token | int | float):
         """
         :type value: lark.Token or int or float
         """
@@ -212,8 +210,11 @@ class Literal(Node):  # literal
             self.value = value
 
     @property
-    def children(self):
+    def children(self) -> list[Node]:
         return []
+
+    def set_child(self, index: int, value: Node) -> None:
+        raise ValueError(f"Cannot set the child of a Literal")
 
     def __str__(self):
         return str(self.value)
@@ -222,7 +223,9 @@ class Literal(Node):  # literal
 class Parenthetical(Node):
     __slots__ = ("value",)
 
-    def __init__(self, value):
+    value: Node
+
+    def __init__(self, value: Node):
         """
         :type value: Node
         """
@@ -233,7 +236,7 @@ class Parenthetical(Node):
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.value = value
 
@@ -244,7 +247,10 @@ class Parenthetical(Node):
 class UnOp(Node):  # u_num
     __slots__ = ("op", "value")
 
-    def __init__(self, op, value):
+    op: str
+    value: Node
+
+    def __init__(self, op: str | Token, value: Node):
         """
         :type op: lark.Token or str
         :type value: Node
@@ -257,7 +263,7 @@ class UnOp(Node):  # u_num
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.value = value
 
@@ -268,7 +274,11 @@ class UnOp(Node):  # u_num
 class BinOp(Node):  # a_num, m_num
     __slots__ = ("op", "left", "right")
 
-    def __init__(self, left, op, right):
+    op: str
+    left: Node
+    right: Node
+
+    def __init__(self, left: Node, op: Token | str, right: Node):
         """
         :type op: lark.Token or str
         :type left: Node
@@ -283,12 +293,12 @@ class BinOp(Node):  # a_num, m_num
     def children(self):
         return [self.left, self.right]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         if self.children[index] is self.left:
-            self.left = value
+            self.left = value  # type: ignore
         else:
-            self.right = value
+            self.right = value  # type: ignore
 
     def __str__(self):
         return f"{str(self.left)} {self.op} {str(self.right)}"
@@ -299,7 +309,10 @@ class SetOperator:  # set_op, dice_op
 
     IMMEDIATE = {"mi", "ma"}
 
-    def __init__(self, op, sels):
+    op: str
+    sels: list["SetSelector"]
+
+    def __init__(self, op: str | Token, sels: list["SetSelector"]):
         """
         :type op: lark.Token or str
         :type sels: list of SetSelector
@@ -308,10 +321,10 @@ class SetOperator:  # set_op, dice_op
         self.sels = sels
 
     @classmethod
-    def new(cls, op, sel):
+    def new(cls, op: str | Token, sel: "SetSelector"):
         return cls(op, [sel])
 
-    def add_sels(self, sels):
+    def add_sels(self, sels: list["SetSelector"]):
         self.sels.extend(sels)
 
     def __str__(self):
@@ -321,7 +334,10 @@ class SetOperator:  # set_op, dice_op
 class SetSelector:  # selector
     __slots__ = ("cat", "num")
 
-    def __init__(self, cat, num):
+    cat: str | None
+    num: int
+
+    def __init__(self, cat: str | Token | None, num: int):
         """
         :type cat: str or lark.Token or None
         :type num: int
@@ -338,7 +354,10 @@ class SetSelector:  # selector
 class OperatedSet(Node):  # set
     __slots__ = ("value", "operations")
 
-    def __init__(self, the_set, *operations):
+    set: "NumberSet | Dice"
+    operations: list[SetOperator]
+
+    def __init__(self, the_set: "NumberSet | Dice", *operations: SetOperator):
         """
         :type the_set: NumberSet or Dice
         :type operations: SetOperator
@@ -352,13 +371,13 @@ class OperatedSet(Node):  # set
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.value = value
 
     def _simplify_operations(self):
         """Simplifies expressions like k1k2k3 into k(1,2,3)."""
-        new_operations = []
+        new_operations: list[SetOperator] = []
 
         for operation in self.operations:
             if operation.op in SetOperator.IMMEDIATE or not new_operations:
@@ -379,7 +398,9 @@ class OperatedSet(Node):  # set
 class NumberSet(Node):  # setexpr
     __slots__ = ("values",)
 
-    def __init__(self, values):
+    values: list[Node]
+
+    def __init__(self, values: list[Node]):
         """
         :type values: list of Node
         """
@@ -390,7 +411,7 @@ class NumberSet(Node):  # setexpr
     def children(self):
         return self.values
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Node):
         self._child_set_check(index)
         self.values[index] = value
 
@@ -408,7 +429,7 @@ class NumberSet(Node):  # setexpr
 class OperatedDice(OperatedSet):  # dice
     __slots__ = ()
 
-    def __init__(self, the_dice, *operations):
+    def __init__(self, the_dice: "Dice", *operations: SetOperator):
         """
         :type the_dice: Dice
         :type operations: SetOperator
@@ -419,7 +440,10 @@ class OperatedDice(OperatedSet):  # dice
 class Dice(Node):  # diceexpr
     __slots__ = ("num", "size")
 
-    def __init__(self, num, size):
+    num: int
+    size: str | int
+
+    def __init__(self, num: int | Token, size: int | str | Token):
         """
         :type num: lark.Token or int
         :type size: lark.Token or int or str
@@ -432,8 +456,11 @@ class Dice(Node):  # diceexpr
             self.size = int(size)
 
     @property
-    def children(self):
+    def children(self) -> list[Node]:
         return []
+
+    def set_child(self, index: int, value: Node) -> None:
+        raise ValueError(f"Cannot set the child of a Dice")
 
     def __str__(self):
         return f"{self.num}d{self.size}"
@@ -448,7 +475,7 @@ parser = Lark(
 if __name__ == "__main__":
     while True:
         parser = Lark(grammar, start=["expr", "commented_expr"], parser="lalr", maybe_placeholders=True)
-        result = parser.parse(input(), start="expr")
+        result = parser.parse(input("> "), start="expr")  # type: ignore
         print(result.pretty())
         print(result)
         expr = RollTransformer().transform(result)

--- a/d20/errors.py
+++ b/d20/errors.py
@@ -1,17 +1,20 @@
 __all__ = ("RollError", "RollSyntaxError", "RollValueError", "TooManyRolls")
 
 
+from typing import Any
+
+
 class RollError(Exception):
     """Generic exception happened in the roll. Base exception for all library exceptions."""
 
-    def __init__(self, msg):
+    def __init__(self, msg: str):
         super().__init__(msg)
 
 
 class RollSyntaxError(RollError):
     """Syntax error happened while parsing roll."""
 
-    def __init__(self, line, col, got, expected):
+    def __init__(self, line: int, col: int, got: Any, expected: Any):
         self.line = line
         self.col = col
         self.got = got

--- a/d20/expression.py
+++ b/d20/expression.py
@@ -1,7 +1,15 @@
 import abc
 from collections.abc import Callable, Iterable, Mapping, Sequence
 import random
-from typing import Optional, TypedDict, Unpack
+
+from typing import Optional, TypedDict
+
+# Prior to 3.12, Unpack was located in typing_extensions rather than typing
+try:
+    from typing import Unpack
+except:
+    from typing_extensions import Unpack
+
 
 from .context import RollContext
 

--- a/d20/expression.py
+++ b/d20/expression.py
@@ -1,5 +1,9 @@
 import abc
+from collections.abc import Callable, Iterable, Mapping, Sequence
 import random
+from typing import Optional, TypedDict, Unpack
+
+from .context import RollContext
 
 from . import diceast as ast, errors, rand
 
@@ -19,7 +23,12 @@ __all__ = (
 
 
 # ===== ast -> expression models =====
-class Number(abc.ABC, ast.ChildMixin):  # num
+class NumberArgs(TypedDict):
+    kept: bool
+    annotation: Optional[str]
+
+
+class Number(abc.ABC, ast.ChildMixin["Number"]):  # num
     """
     The base class for all expression objects.
 
@@ -28,12 +37,15 @@ class Number(abc.ABC, ast.ChildMixin):  # num
 
     __slots__ = ("kept", "annotation")
 
-    def __init__(self, kept=True, annotation=None):
+    kept: bool
+    annotation: Optional[str]
+
+    def __init__(self, kept: bool = True, annotation: Optional[str] = None):
         self.kept = kept
         self.annotation = annotation
 
     @property
-    def number(self):
+    def number(self) -> int | float:
         """
         Returns the numerical value of this object.
 
@@ -42,7 +54,7 @@ class Number(abc.ABC, ast.ChildMixin):  # num
         return sum(n.number for n in self.keptset)
 
     @property
-    def total(self):
+    def total(self) -> int | float:
         """
         Returns the numerical value of this object with respect to whether it's kept.
         Generally, this is preferred to use over ``number``, as this will return 0 if
@@ -53,7 +65,8 @@ class Number(abc.ABC, ast.ChildMixin):  # num
         return self.number if self.kept else 0
 
     @property
-    def set(self):
+    @abc.abstractmethod
+    def set(self) -> Sequence["Number"]:
         """
         Returns the set representation of this object.
 
@@ -86,29 +99,16 @@ class Number(abc.ABC, ast.ChildMixin):  # num
     def __repr__(self):
         return f"<Number total={self.total} kept={self.kept}>"
 
-    # overridden methods for typechecking
-    def set_child(self, index, value):
-        """
-        Sets the ith child of this Number.
-
-        :param int index: Which child to set.
-        :param value: The Number to set it to.
-        :type value: Number
-        """
-        super().set_child(index, value)
-
-    @property
-    def children(self):
-        """:rtype: list[Number]"""
-        raise NotImplementedError
-
 
 class Expression(Number):
     """Expressions are usually the root of all Number trees."""
 
     __slots__ = ("roll", "comment")
 
-    def __init__(self, roll, comment, **kwargs):
+    roll: Number
+    comment: Optional[str]
+
+    def __init__(self, roll: Number, comment: Optional[str], **kwargs: Unpack[NumberArgs]):
         """
         :type roll: Number
         """
@@ -128,7 +128,7 @@ class Expression(Number):
     def children(self):
         return [self.roll]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Number):
         self._child_set_check(index)
         self.roll = value
 
@@ -141,7 +141,10 @@ class Literal(Number):
 
     __slots__ = ("values", "exploded")
 
-    def __init__(self, value, **kwargs):
+    values: list[int | float]
+    exploded: bool
+
+    def __init__(self, value: int | float, **kwargs: Unpack[NumberArgs]):
         """
         :type value: int or float
         """
@@ -154,21 +157,24 @@ class Literal(Number):
         return self.values[-1]
 
     @property
-    def set(self):
+    def set(self) -> list[Number]:
         return [self]
 
     @property
-    def children(self):
+    def children(self) -> list[Number]:
         return []
 
     def explode(self):
         self.exploded = True
 
-    def update(self, value):
+    def update(self, value: int | float):
         """
         :type value: int or float
         """
         self.values.append(value)
+
+    def set_child(self, index: int, value: Number) -> None:
+        raise ValueError(f"Cannot set the child of a Literal")
 
     def __repr__(self):
         return f"<Literal {self.number}>"
@@ -179,9 +185,12 @@ class UnOp(Number):
 
     __slots__ = ("op", "value")
 
-    UNARY_OPS = {"-": lambda v: -v, "+": lambda v: +v}
+    op: str
+    value: Number
 
-    def __init__(self, op, value, **kwargs):
+    UNARY_OPS: Mapping[str, Callable[[int | float], int | float]] = {"-": lambda v: -v, "+": lambda v: +v}
+
+    def __init__(self, op: str, value: Number, **kwargs: Unpack[NumberArgs]):
         """
         :type op: str
         :type value: Number
@@ -195,14 +204,14 @@ class UnOp(Number):
         return self.UNARY_OPS[self.op](self.value.total)
 
     @property
-    def set(self):
+    def set(self) -> list[Number]:
         return [self]
 
     @property
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Number):
         self._child_set_check(index)
         self.value = value
 
@@ -215,7 +224,11 @@ class BinOp(Number):
 
     __slots__ = ("op", "left", "right")
 
-    BINARY_OPS = {
+    op: str
+    left: Number
+    right: Number
+
+    BINARY_OPS: Mapping[str, Callable[[int | float, int | float], int | float]] = {
         "+": lambda l, r: l + r,
         "-": lambda l, r: l - r,
         "*": lambda l, r: l * r,
@@ -230,7 +243,7 @@ class BinOp(Number):
         "!=": lambda l, r: int(l != r),
     }
 
-    def __init__(self, left, op, right, **kwargs):
+    def __init__(self, left: Number, op: str, right: Number, **kwargs: Unpack[NumberArgs]):
         """
         :type op: str
         :type left: Number
@@ -249,19 +262,19 @@ class BinOp(Number):
             raise errors.RollValueError("Cannot divide by zero.")
 
     @property
-    def set(self):
+    def set(self) -> list[Number]:
         return [self]
 
     @property
     def children(self):
         return [self.left, self.right]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Number):
         self._child_set_check(index)
         if self.children[index] is self.left:
-            self.left = value
+            self.left = value  # type: ignore
         else:
-            self.right = value
+            self.right = value  # type: ignore
 
     def __repr__(self):
         return f"<BinOp left={self.left} op={self.op} right={self.right}>"
@@ -272,7 +285,15 @@ class Parenthetical(Number):
 
     __slots__ = ("value", "operations")
 
-    def __init__(self, value, operations=None, **kwargs):
+    value: Number
+    operations: list["SetOperator"]
+
+    def __init__(
+        self,
+        value: Number,
+        operations: Optional[list["SetOperator"]] = None,
+        **kwargs: Unpack[NumberArgs],
+    ):
         """
         :type value: Number
         :type operations: list[SetOperator]
@@ -295,7 +316,7 @@ class Parenthetical(Number):
     def children(self):
         return [self.value]
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Number):
         self._child_set_check(index)
         self.value = value
 
@@ -308,7 +329,15 @@ class Set(Number):
 
     __slots__ = ("values", "operations")
 
-    def __init__(self, values, operations=None, **kwargs):
+    values: list[Number]
+    operations: list["SetOperator"]
+
+    def __init__(
+        self,
+        values: list[Number],
+        operations: Optional[list["SetOperator"]] = None,
+        **kwargs: Unpack[NumberArgs],
+    ):
         """
         :type values: list[Number]
         :type operations: list[SetOperator]
@@ -320,14 +349,14 @@ class Set(Number):
         self.operations = operations
 
     @property
-    def set(self):
+    def set(self) -> list[Number]:
         return self.values
 
     @property
-    def children(self):
+    def children(self) -> list[Number]:
         return self.values
 
-    def set_child(self, index, value):
+    def set_child(self, index: int, value: Number):
         self._child_set_check(index)
         self.values[index] = value
 
@@ -335,7 +364,12 @@ class Set(Number):
         return f"<Set values={self.values} operations={self.operations}>"
 
     def __copy__(self):
-        return Set(values=self.values.copy(), operations=self.operations.copy())
+        return Set(
+            values=self.values.copy(),
+            operations=self.operations.copy(),
+            kept=self.kept,
+            annotation=self.annotation,
+        )
 
 
 class Dice(Set):
@@ -343,7 +377,23 @@ class Dice(Set):
 
     __slots__ = ("num", "size", "_context", "_rng")
 
-    def __init__(self, num, size, values, operations=None, context=None, rng=rand.random_impl, **kwargs):
+    num: int
+    size: int | str
+    values: list["Number"]
+    operations: list["SetOperator"]
+    _context: Optional[RollContext]
+    _rng: random.Random
+
+    def __init__(
+        self,
+        num: int,
+        size: int | str,
+        values: list[Number],
+        operations: Optional[list["SetOperator"]] = None,
+        context: Optional[RollContext] = None,
+        rng: random.Random = rand.random_impl,
+        **kwargs: Unpack[NumberArgs],
+    ):
         """
         :type num: int
         :type size: int|str
@@ -359,14 +409,28 @@ class Dice(Set):
         self._rng = rng
 
     @classmethod
-    def new(cls, num, size, context=None, rng=rand.random_impl):
-        return cls(num, size, [Die.new(size, context=context, rng=rng) for _ in range(num)], context=context, rng=rng)
+    def new(
+        cls,
+        num: int,
+        size: int | str,
+        context: Optional[RollContext] = None,
+        rng: random.Random = rand.random_impl,
+        **kwargs: Unpack[NumberArgs],
+    ):
+        return cls(
+            num,
+            size,
+            [Die.new(size, context=context, rng=rng) for _ in range(num)],
+            context=context,
+            rng=rng,
+            **kwargs,
+        )
 
     def roll_another(self):
         self.values.append(Die.new(self.size, context=self._context, rng=self._rng))
 
     @property
-    def children(self):
+    def children(self) -> list[Number]:
         return []
 
     def __repr__(self):
@@ -380,6 +444,8 @@ class Dice(Set):
             rng=self._rng,
             values=self.values.copy(),
             operations=self.operations.copy(),
+            kept=self.kept,
+            annotation=self.annotation,
         )
 
 
@@ -388,7 +454,18 @@ class Die(Number):  # part of diceexpr
 
     __slots__ = ("size", "values", "_context", "_rng")
 
-    def __init__(self, size, values, context=None, rng=rand.random_impl):
+    size: int | str
+    values: list[Literal]
+    _context: Optional[RollContext]
+    _rng: random.Random
+
+    def __init__(
+        self,
+        size: int | str,
+        values: list[Literal],
+        context: Optional[RollContext] = None,
+        rng: random.Random = rand.random_impl,
+    ):
         """
         :type size: int
         :type values: list of Literal
@@ -402,7 +479,9 @@ class Die(Number):  # part of diceexpr
         self._rng = rng
 
     @classmethod
-    def new(cls, size, context=None, rng=rand.random_impl):
+    def new(
+        cls, size: int | str, context: Optional[RollContext] = None, rng: random.Random = rand.random_impl
+    ) -> "Die":
         inst = cls(size, [], context=context, rng=rng)
         inst._add_roll()
         return inst
@@ -412,25 +491,28 @@ class Die(Number):  # part of diceexpr
         return self.values[-1].total
 
     @property
-    def set(self):
+    def set(self) -> list[Number]:
         return [self.values[-1]]
 
     @property
-    def children(self):
+    def children(self) -> list[Number]:
         return []
 
     def _add_roll(self):
-        if self.size != "%" and self.size < 1:
+        if self.size != "%" and isinstance(self.size, int) and self.size < 1:
             raise errors.RollValueError("Cannot roll a 0-sided die.")
         if self._context:
             self._context.count_roll()
         if self.size == "%":
-            n = Literal(self._rng.randrange(10) * 10)
+            n = Literal(self._rng.randrange(10) * 10, kept=self.kept, annotation=self.annotation)
+        elif isinstance(self.size, int):
+            # 200ns faster than randint(1, self._size)
+            n = Literal(self._rng.randrange(self.size) + 1, kept=self.kept, annotation=self.annotation)
         else:
-            n = Literal(self._rng.randrange(self.size) + 1)  # 200ns faster than randint(1, self._size)
+            raise ValueError(f"Invalid die size value: '{self.size}'")
         self.values.append(n)
 
-    def reroll(self):
+    def reroll(self) -> None:
         if self.values:
             self.values[-1].drop()
         self._add_roll()
@@ -440,7 +522,7 @@ class Die(Number):  # part of diceexpr
             self.values[-1].explode()
         # another Die is added by the explode operator
 
-    def force_value(self, new_value):
+    def force_value(self, new_value: int | float):
         if self.values:
             self.values[-1].update(new_value)
 
@@ -455,7 +537,10 @@ class SetOperator:  # set_op, dice_op
 
     __slots__ = ("op", "sels")
 
-    def __init__(self, op, sels):
+    op: str
+    sels: list["SetSelector"]
+
+    def __init__(self, op: str, sels: list["SetSelector"]):
         """
         :type op: str
         :type sels: list[SetSelector]
@@ -464,10 +549,14 @@ class SetOperator:  # set_op, dice_op
         self.sels = sels
 
     @classmethod
-    def from_ast(cls, node):
+    def from_ast(cls, node: ast.SetOperator):
         return cls(node.op, [SetSelector.from_ast(n) for n in node.sels])
 
-    def select(self, target, max_targets=None):
+    @staticmethod
+    def filter_die(target: Iterable[Number]) -> set[Die]:
+        return set(die for die in target if isinstance(die, Die))
+
+    def select(self, target: Set, max_targets: Optional[int] = None) -> set[Number]:
         """
         Selects the operands in a target set.
 
@@ -476,7 +565,7 @@ class SetOperator:  # set_op, dice_op
         :param max_targets: The maximum number of targets to select.
         :type max_targets: Optional[int]
         """
-        out = set()
+        out: set[Number] = set()
         for selector in self.sels:
             batch_max = None
             if max_targets is not None:
@@ -487,14 +576,14 @@ class SetOperator:  # set_op, dice_op
             out.update(selector.select(target, max_targets=batch_max))
         return out
 
-    def operate(self, target):
+    def operate(self, target: Set):
         """
         Operates in place on the values in a target set.
 
         :param target: The source of the operands.
-        :type target: Number
+        :type target: Set
         """
-        operations = {
+        operations: Mapping[str, Callable[[Set], None]] = {
             "k": self.keep,
             "p": self.drop,
             # dice only
@@ -508,7 +597,7 @@ class SetOperator:  # set_op, dice_op
 
         operations[self.op](target)
 
-    def keep(self, target):
+    def keep(self, target: Set):
         """
         :type target: Set
         """
@@ -516,37 +605,44 @@ class SetOperator:  # set_op, dice_op
             if value not in self.select(target):
                 value.drop()
 
-    def drop(self, target):
+    def drop(self, target: Set):
         """
         :type target: Set
         """
         for value in self.select(target):
             value.drop()
 
-    def reroll(self, target):
+    def reroll(self, target: Set):
         """
         :type target: Dice
         """
-        to_reroll = self.select(target)
+        if not isinstance(target, Dice):
+            return
+
+        to_reroll = self.filter_die(self.select(target))
+
         while to_reroll:
             for die in to_reroll:
                 die.reroll()
 
-            to_reroll = self.select(target)
+            to_reroll = self.filter_die(self.select(target))
 
-    def reroll_once(self, target):
+    def reroll_once(self, target: Set):
         """
         :type target: Dice
         """
-        for die in self.select(target):
+        for die in self.filter_die(self.select(target)):
             die.reroll()
 
-    def explode(self, target):
+    def explode(self, target: Set):
         """
         :type target: Dice
         """
-        to_explode = self.select(target)
-        already_exploded = set()
+        if not isinstance(target, Dice):
+            return
+
+        to_explode = self.filter_die(self.select(target))
+        already_exploded: set[Die] = set()
 
         while to_explode:
             for die in to_explode:
@@ -554,17 +650,20 @@ class SetOperator:  # set_op, dice_op
                 target.roll_another()
 
             already_exploded.update(to_explode)
-            to_explode = self.select(target).difference(already_exploded)
+            to_explode = self.filter_die(self.select(target)).difference(already_exploded)
 
-    def explode_once(self, target):
+    def explode_once(self, target: Set):
         """
         :type target: Dice
         """
-        for die in self.select(target, max_targets=1):
+        if not isinstance(target, Dice):
+            return
+
+        for die in self.filter_die(self.select(target, max_targets=1)):
             die.explode()
             target.roll_another()
 
-    def minimum(self, target):  # immediate
+    def minimum(self, target: Set):  # immediate
         """
         :type target: Dice
         """
@@ -572,11 +671,11 @@ class SetOperator:  # set_op, dice_op
         if selector.cat is not None:
             raise errors.RollValueError(f"{str(selector)} is not a valid selector for minimums.")
         the_min = selector.num
-        for die in target.keptset:
+        for die in self.filter_die(target.keptset):
             if die.number < the_min:
                 die.force_value(the_min)
 
-    def maximum(self, target):  # immediate
+    def maximum(self, target: Set):  # immediate
         """
         :type target: Dice
         """
@@ -584,7 +683,7 @@ class SetOperator:  # set_op, dice_op
         if selector.cat is not None:
             raise errors.RollValueError(f"{str(selector)} is not a valid selector for maximums.")
         the_max = selector.num
-        for die in target.keptset:
+        for die in self.filter_die(target.keptset):
             if die.number > the_max:
                 die.force_value(the_max)
 
@@ -600,7 +699,10 @@ class SetSelector:  # selector
 
     __slots__ = ("cat", "num")
 
-    def __init__(self, cat, num):
+    cat: str | None
+    num: int
+
+    def __init__(self, cat: str | None, num: int):
         """
         :type cat: str or None
         :type num: int
@@ -609,15 +711,15 @@ class SetSelector:  # selector
         self.num = num
 
     @classmethod
-    def from_ast(cls, node):
+    def from_ast(cls, node: ast.SetSelector):
         return cls(node.cat, node.num)
 
-    def select(self, target, max_targets=None):
+    def select(self, target: Set, max_targets: Optional[int] = None) -> set[Number]:
         """
         Selects operands from a target set.
 
         :param target: The source of the operands.
-        :type target: Number
+        :type target: Set
         :param int max_targets: The maximum number of targets to select.
         :return: The targets in the set.
         :rtype: set of Number
@@ -629,19 +731,19 @@ class SetSelector:  # selector
             selected = selected[:max_targets]
         return set(selected)
 
-    def lowestn(self, target):
+    def lowestn(self, target: Set):
         return sorted(target.keptset, key=lambda n: n.total)[: self.num]
 
-    def highestn(self, target):
+    def highestn(self, target: Set):
         return sorted(target.keptset, key=lambda n: n.total, reverse=True)[: self.num]
 
-    def lessthan(self, target):
+    def lessthan(self, target: Set):
         return [n for n in target.keptset if n.total < self.num]
 
-    def morethan(self, target):
+    def morethan(self, target: Set):
         return [n for n in target.keptset if n.total > self.num]
 
-    def literal(self, target):
+    def literal(self, target: Set):
         return [n for n in target.keptset if n.total == self.num]
 
     def __str__(self):

--- a/d20/rand.py
+++ b/d20/rand.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, NewType, Optional, Sequence, Type, Union
 
 __all__ = ("random_impl",)
 
-_BitGenT = NewType("_BitGenT", Any)
+_BitGenT = NewType("_BitGenT", Any)  # type: ignore
 _SeedT = Optional[Union[int, Sequence[int]]]
 
 # the default random implementation - just use stdlib random (MT2002)
@@ -41,11 +41,11 @@ try:
     class NumpyRandom(random.Random):
         _gen: Generator
 
-        def __init__(self, bitgen_type: Type[_BitGenT], x: _SeedT = None):
-            self._bitgen_type = bitgen_type
+        def __init__(self, bitgen_type: Type[_BitGenT], x: _SeedT = None):  # pyright: ignore
+            self._bitgen_type = bitgen_type  # pyright: ignore[reportUnknownMemberType]
             # Random.__init__() calls seed(), so we let seed() initialize the Generator instance to avoid instantiating
             # it twice (once in __init__, once in seed())
-            super().__init__(x)
+            super().__init__(x)  # pyright: ignore[reportUnknownArgumentType]
 
         def random(self) -> float:
             return self._gen.random()
@@ -64,16 +64,16 @@ try:
             # (tested on 1.17.5)
             return self._gen.bytes(n)
 
-        def seed(self, a: _SeedT = None, version: int = 2):
+        def seed(self, a: _SeedT = None, version: int = 2):  # type: ignore
             # note that this takes in a different type than random.Random.seed()
             # this is because BitGenerator's seed requires an int/sequence of ints, while Random accepts
             # floats, strs, etc; for the common case we expect the user to pass an int
-            self._gen = Generator(self._bitgen_type(a))
+            self._gen = Generator(self._bitgen_type(a))  # type: ignore
 
-        def getstate(self):
+        def getstate(self):  # type: ignore
             return self._gen.bit_generator.state
 
-        def setstate(self, state):
+        def setstate(self, state: Any):
             self._gen.bit_generator.state = state
 
     if hasattr(numpy.random, "PCG64DXSM"):  # available in numpy 1.21 and up

--- a/d20/stringifiers.py
+++ b/d20/stringifiers.py
@@ -1,11 +1,9 @@
 import abc
-from typing import Callable, Iterable, Mapping, Type, TypeVar
+from typing import Any, Callable, Iterable, Mapping, Type
 
 from .expression import *
 
 __all__ = ("Stringifier", "SimpleStringifier", "MarkdownStringifier")
-
-ExpressionNode = TypeVar("ExpressionNode", bound=Number)
 
 
 class Stringifier(abc.ABC):
@@ -15,7 +13,7 @@ class Stringifier(abc.ABC):
     """
 
     def __init__(self):
-        self._nodes: Mapping[Type[ExpressionNode], Callable[[ExpressionNode], str]] = {
+        self._nodes: Mapping[Type[Number], Callable[[Any], str]] = {
             Expression: self._str_expression,
             Literal: self._str_literal,
             UnOp: self._str_unop,
@@ -26,7 +24,7 @@ class Stringifier(abc.ABC):
             Die: self._str_die,
         }
 
-    def stringify(self, the_roll: ExpressionNode) -> str:
+    def stringify(self, the_roll: Number) -> str:
         """
         Transforms a rolled expression into a string recursively, bottom-up.
 
@@ -36,7 +34,7 @@ class Stringifier(abc.ABC):
         """
         return self._stringify(the_roll)
 
-    def _stringify(self, node: ExpressionNode) -> str:
+    def _stringify(self, node: Number) -> str:
         """
         Called on each node that needs to be stringified.
 
@@ -124,35 +122,35 @@ class SimpleStringifier(Stringifier):
     Example stringifier.
     """
 
-    def _str_expression(self, node):
+    def _str_expression(self, node: Expression):
         return f"{self._stringify(node.roll)} = {int(node.total)}"
 
-    def _str_literal(self, node):
+    def _str_literal(self, node: Literal):
         history = " -> ".join(map(str, node.values))
         if node.exploded:
             return f"{history}!"
         return history
 
-    def _str_unop(self, node):
+    def _str_unop(self, node: UnOp):
         return f"{node.op}{self._stringify(node.value)}"
 
-    def _str_binop(self, node):
+    def _str_binop(self, node: BinOp):
         return f"{self._stringify(node.left)} {node.op} {self._stringify(node.right)}"
 
-    def _str_parenthetical(self, node):
+    def _str_parenthetical(self, node: Parenthetical):
         return f"({self._stringify(node.value)}){self._str_ops(node.operations)}"
 
-    def _str_set(self, node):
+    def _str_set(self, node: Set):
         out = f"{', '.join([self._stringify(v) for v in node.values])}"
         if len(node.values) == 1:
             return f"({out},){self._str_ops(node.operations)}"
         return f"({out}){self._str_ops(node.operations)}"
 
-    def _str_dice(self, node):
+    def _str_dice(self, node: Dice):
         the_dice = [self._stringify(die) for die in node.values]
         return f"{node.num}d{node.size}{self._str_ops(node.operations)} ({', '.join(the_dice)})"
 
-    def _str_die(self, node):
+    def _str_die(self, node: Die):
         the_rolls = [self._stringify(val) for val in node.values]
         return ", ".join(the_rolls)
 
@@ -173,11 +171,11 @@ class MarkdownStringifier(SimpleStringifier):
         super().__init__()
         self._context = self._MDContext()
 
-    def stringify(self, the_roll):
+    def stringify(self, the_roll: Number):
         self._context.reset()
         return super().stringify(the_roll)
 
-    def _stringify(self, node):
+    def _stringify(self, node: Number):
         if not node.kept and not self._context.in_dropped:
             self._context.in_dropped = True
             inside = super()._stringify(node)
@@ -185,11 +183,11 @@ class MarkdownStringifier(SimpleStringifier):
             return f"~~{inside}~~"
         return super()._stringify(node)
 
-    def _str_expression(self, node):
+    def _str_expression(self, node: Expression):
         return f"{self._stringify(node.roll)} = `{int(node.total)}`"
 
-    def _str_die(self, node):
-        the_rolls = []
+    def _str_die(self, node: Die):
+        the_rolls: list[str] = []
         for val in node.values:
             inside = self._stringify(val)
             if val.number == 1 or val.number == node.size:

--- a/d20/utils.py
+++ b/d20/utils.py
@@ -1,16 +1,14 @@
 import copy
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
-import d20  # this import is here for the doctests
+import d20  # type: ignore # this import is here for the doctests
 from d20 import diceast, expression
 from .dice import AdvType
 
-TreeType = TypeVar("TreeType", bound=diceast.ChildMixin)
-ASTNode = TypeVar("ASTNode", bound=diceast.Node)
-ExpressionNode = TypeVar("ExpressionNode", bound=expression.Number)
+TreeType = TypeVar("TreeType", bound=diceast.ChildMixin[Any])
 
 
-def ast_adv_copy(ast: ASTNode, advtype: AdvType) -> ASTNode:
+def ast_adv_copy(ast: diceast.Node, advtype: AdvType) -> diceast.Node:
     """
     Returns a minimally shallow copy of a dice AST with respect to advantage.
 
@@ -33,7 +31,7 @@ def ast_adv_copy(ast: ASTNode, advtype: AdvType) -> ASTNode:
     parent = child = root
     while child.children:
         parent = child
-        parent.left = child = copy.copy(parent.left)
+        parent.left = child = copy.copy(parent.left) # type: ignore
 
     # is it dice?
     if not isinstance(child, diceast.Dice):
@@ -46,7 +44,7 @@ def ast_adv_copy(ast: ASTNode, advtype: AdvType) -> ASTNode:
     # does it already have operations?
     if not isinstance(parent, diceast.OperatedDice):
         new_parent = diceast.OperatedDice(child)
-        parent.left = new_parent
+        parent.left = new_parent # type: ignore
         parent = new_parent
     else:
         parent.operations = parent.operations.copy()
@@ -65,7 +63,7 @@ def ast_adv_copy(ast: ASTNode, advtype: AdvType) -> ASTNode:
     return root
 
 
-def simplify_expr_annotations(expr: ExpressionNode, ambig_inherit: Optional[str] = None):
+def simplify_expr_annotations(expr: expression.Number, ambig_inherit: Optional[str] = None):
     """
     Transforms an expression in place by simplifying the annotations using a bubble-up method.
 
@@ -82,9 +80,9 @@ def simplify_expr_annotations(expr: ExpressionNode, ambig_inherit: Optional[str]
     if ambig_inherit not in ("left", "right", None):
         raise ValueError("ambig_inherit must be 'left', 'right', or None.")
 
-    def do_simplify(node):
-        possible_types = []
-        child_possibilities = {}
+    def do_simplify(node: expression.Number) -> tuple[str, ...]:
+        possible_types: list[str] = []
+        child_possibilities: dict[expression.Number, tuple[str, ...]] = {}
         for child in node.children:
             child_possibilities[child] = do_simplify(child)
             possible_types.extend(t for t in child_possibilities[child] if t not in possible_types)
@@ -117,7 +115,7 @@ def simplify_expr_annotations(expr: ExpressionNode, ambig_inherit: Optional[str]
     do_simplify(expr)
 
 
-def simplify_expr(expr: expression.Expression, **kwargs):
+def simplify_expr(expr: expression.Expression, ambig_inherit: Optional[str] = None):
     """
     Transforms an expression in place by simplifying it (removing all dice and evaluating branches with respect to
     annotations).
@@ -130,15 +128,15 @@ def simplify_expr(expr: expression.Expression, **kwargs):
     :param d20.Expression expr: The expression to transform.
     :param kwargs: Arguments that are passed to :func:`simplify_expr_annotations`.
     """
-    simplify_expr_annotations(expr.roll, **kwargs)
+    simplify_expr_annotations(expr.roll, ambig_inherit)
 
-    def do_simplify(node, first=False):
+    def do_simplify(node: expression.Number, first: bool = False) -> tuple[expression.Number, bool]:
         """returns a pair of (replacement, branch had replacement)"""
         if node.annotation:
-            return expression.Literal(node.total, annotation=node.annotation), True
+            return expression.Literal(node.total, kept=node.kept, annotation=node.annotation), True
 
         # pass 1: recursively replace branches with annotations, marking which branches had replacements
-        had_replacement = set()
+        had_replacement: set[int] = set()
         for i, child in enumerate(node.children):
             replacement, branch_had = do_simplify(child)
             if branch_had:
@@ -150,7 +148,7 @@ def simplify_expr(expr: expression.Expression, **kwargs):
         for i, child in enumerate(node.children):
             if (i not in had_replacement) and (had_replacement or first):
                 # here is the furthest we can bubble up a no-annotation branch
-                replacement = expression.Literal(child.total)
+                replacement = expression.Literal(child.total, kept=child.kept, annotation=child.annotation)
                 node.set_child(i, replacement)
 
         return node, bool(had_replacement)

--- a/d20/utils.py
+++ b/d20/utils.py
@@ -29,9 +29,9 @@ def ast_adv_copy(ast: diceast.Node, advtype: AdvType) -> diceast.Node:
 
     # find the leftmost node, making shallow copies all the way down
     parent = child = root
-    while child.children:
+    while child.children:  # type: ignore
         parent = child
-        parent.left = child = copy.copy(parent.left) # type: ignore
+        parent.left = child = copy.copy(parent.left)  # type: ignore
 
     # is it dice?
     if not isinstance(child, diceast.Dice):
@@ -44,7 +44,7 @@ def ast_adv_copy(ast: diceast.Node, advtype: AdvType) -> diceast.Node:
     # does it already have operations?
     if not isinstance(parent, diceast.OperatedDice):
         new_parent = diceast.OperatedDice(child)
-        parent.left = new_parent # type: ignore
+        parent.left = new_parent  # type: ignore
         parent = new_parent
     else:
         parent.operations = parent.operations.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ reverse_relative = true
 combine_as_imports = true
 
 [tool.pyright]
-include = ["d20", "tests"]
+include = ["d20"]
 exclude = ["**/__pycache__", "./testparser.py"]
 typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "d20"
 version = "1.1.2"
-authors = [
-    { name = "Andrew Zhu", email = "andrew@zhu.codes" },
-]
+authors = [{ name = "Andrew Zhu", email = "andrew@zhu.codes" }]
 description = "A formal grammar-based dice parser and roller for D&D and other dice systems."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -21,15 +19,10 @@ classifiers = [
     "Topic :: Games/Entertainment :: Board Games",
     "Topic :: Games/Entertainment :: Role-Playing",
 ]
-dependencies = [
-    "cachetools>=3.1.0,<6.0.0",
-    "lark>=0.9.0,<2.0.0",
-]
+dependencies = ["cachetools>=3.1.0,<6.0.0", "lark>=0.9.0,<2.0.0"]
 
 [project.optional-dependencies]
-numpy = [
-    "numpy>=1.17.0,<2.0.0",
-]
+numpy = ["numpy>=1.17.0,<2.0.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/zhudotexe/d20"
@@ -48,3 +41,8 @@ known_first_party = ["d20"]
 no_lines_before = "LOCALFOLDER"
 reverse_relative = true
 combine_as_imports = true
+
+[tool.pyright]
+include = ["d20", "tests"]
+exclude = ["**/__pycache__", "./testparser.py"]
+typeCheckingMode = "strict"


### PR DESCRIPTION
This PR adds missing type hints and pyright checking in the github workflow. A full list of changes is given:

- Pyright support was added, with the mode set to 'strict'. This means that the linter will raise an error in case a linting failure occurs. These settings are added in pyproject.toml, though pyright is not included in requirements.txt.

- Typing was added to every file in the d20 package where required. Several types were also fixed, such as optional values not being marked with Optional. RollTranformer largely uses Any, due to the underlying Lark library.

- Pyright issues and typings that could not be fixed were marked with `#type: ignore`. This includes a large part of rand.py, which I could not fix as I do not fully understand the underling code. 

- RollContext is moved to a separate file named context.py, in order to avoid circular imports.

- TypeVars that did not meaningfully add type hinting, i.e. they only were used in place for their bound value, were removed.

- ChildMixin is now templated with TypeVars, and its expected type indicates what type the children are. For example, for Node the children are list[Node] and for Number the children are list[Number].

- In several places, typing.cast is used to tell the type checker what type an object has. This should have no impact on the runtime or performance.

- Missing kwargs args are added to Number and its subclasses. These kwargs are packaged together in the NumberArgs class.

- The @abstractmethod decorator is added where appropriate. Some classes inherited abstract methods they could not use. To compensate, these raise errors.

- SetOperator is given a new method named filter_die, which filters Die from a set of Numbers. In practice this method has no purpose, but it's required to please the type checker. Similarly, SetOperators meant to be used on Dice now explicitly checks if they are performed on Dice.

- In the pytest workflow file, support for Python versions 3.7, 3.8, and 3.9 was removed, as these tests failed in the workflows due to being outdated. It may be possible to re-add these, though I do not know how.

- .gitignore is updated to include .vscode. I apologize for this, but I did not want to accidentally push my .vscode directory to the git.
